### PR TITLE
add GitHub Actions workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,43 @@
+on:
+  pull_request:
+    paths-ignore:
+      - "*.md"
+      - ".txt"
+
+  push:
+    paths-ignore:
+      - "*.md"
+      - ".txt"
+    branches:
+     - master
+
+jobs:
+
+  build:
+    name: "Build and test"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.12"
+
+      - uses: actions/checkout@v1
+
+      - name: "build source workspace"
+        run: "make workspace"
+
+      - name: "golang pkg cache"
+        uses: "actions/cache@v1"
+        with:
+          path: "~/go/pkg"
+          key: "pkg-${{hashFiles('go.mod')}}"
+
+      - name: "lint and test"
+        run: "make check"
+
+      - name: "build"
+        run: "make build"
+
+      - name: "package"
+        run: "make release"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@ repo := plan-client-phost
 # ----------------------------------------
 # dev/test
 
-.PHONY: check fmt lint test
+.PHONY: check fmt lint test workspace
+
+workspace:
+	git clone https://github.com/plan-systems/plan-core.git \
+		../plan-core
+	git clone https://github.com/plan-systems/plan-pdi-local.git \
+		../plan-pdi-local
 
 check: fmt lint test
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 P  L  A  N etwork
 ```
 
-[![ci.machinistlabs.com](https://ci.machinistlabs.com/api/v1/teams/plan/pipelines/plan/jobs/plan-client-phost/badge)](https://ci.machinistlabs.com/teams/plan/pipelines/plan)
+![](https://github.com/plan-systems/plan-client-phost/workflows/Build%20and%20test/badge.svg)
 
 [PLAN](http://plan-systems.org) is a free and open platform for groups to securely communicate, collaborate, and coordinate projects and activities.
 


### PR DESCRIPTION
Migrates the CI process to use GitHub Actions. See https://github.com/plan-systems/plan-core/pull/19 for more context.